### PR TITLE
cs42l84: Fix control name in EnableSequence

### DIFF
--- a/ucm2/conf.d/macaudio/cs42l84/Headphones.conf
+++ b/ucm2/conf.d/macaudio/cs42l84/Headphones.conf
@@ -1,6 +1,6 @@
 SectionVerb {
 	EnableSequence [
-		cset "name='Jack ADC WNF Switch' on"
+		cset "name='Jack ADC WNF' on"
 	]
 }
 


### PR DESCRIPTION
Fixes headphone audio using pipewire/wireplumbler on j314 and j493.

Signed-off-by: Janne Grunau <j@jannau.net>