### PR TITLE
Add a 'Comment "Default"' to the "HiFi" use case

### DIFF
--- a/ucm2/conf.d/macaudio/Mac Studio J375.conf
+++ b/ucm2/conf.d/macaudio/Mac Studio J375.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "j375/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/Mac mini J274.conf
+++ b/ucm2/conf.d/macaudio/Mac mini J274.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "j274/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/MacBook Air J313.conf
+++ b/ucm2/conf.d/macaudio/MacBook Air J313.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "laptops1/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/MacBook Air J413.conf
+++ b/ucm2/conf.d/macaudio/MacBook Air J413.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "laptops2/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/MacBook Pro J293.conf
+++ b/ucm2/conf.d/macaudio/MacBook Pro J293.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "laptops1/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/MacBook Pro J314.conf
+++ b/ucm2/conf.d/macaudio/MacBook Pro J314.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "laptops2/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/MacBook Pro J316.conf
+++ b/ucm2/conf.d/macaudio/MacBook Pro J316.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "laptops2/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/MacBook Pro J493.conf
+++ b/ucm2/conf.d/macaudio/MacBook Pro J493.conf
@@ -1,5 +1,6 @@
 Syntax 6
 
 SectionUseCase."HiFi" {
+	Comment "Default"
 	File "laptops2/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/iMac J456.conf
+++ b/ucm2/conf.d/macaudio/iMac J456.conf
@@ -4,5 +4,6 @@ SectionUseCase."HiFi" {
 	# Well, sure, the iMac isn't a laptop, but it needs essentially
 	# the same config. (That is until there will be support for the
 	# internal mic on the laptops.)
+	Comment "Default"
 	File "laptops1/HiFi.conf"
 }

--- a/ucm2/conf.d/macaudio/iMac J457.conf
+++ b/ucm2/conf.d/macaudio/iMac J457.conf
@@ -4,5 +4,6 @@ SectionUseCase."HiFi" {
 	# Well, sure, the iMac isn't a laptop, but it needs essentially
 	# the same config. (That is until there will be support for the
 	# internal mic on the laptops.)
+	Comment "Default"
 	File "laptops1/HiFi.conf"
 }


### PR DESCRIPTION
This avoids displaying a confusing "n/a" as profile name in plasma's audio config.