### PR TITLE
Fix speaker detection by using an unique id for each macro invocation

### DIFF
--- a/ucm2/conf.d/macaudio/DetectSpeaker.conf
+++ b/ucm2/conf.d/macaudio/DetectSpeaker.conf
@@ -14,6 +14,6 @@ DefineMacro.CheckSpkControl {
 }
 
 Macro.spkdet1.CheckSpkControl "prefix=''"
-Macro.spkdet1.CheckSpkControl "prefix='Left '"
-Macro.spkdet1.CheckSpkControl "prefix='Left Front '"
-Macro.spkdet1.CheckSpkControl "prefix='Left Tweeter '"
+Macro.spkdet2.CheckSpkControl "prefix='Left '"
+Macro.spkdet3.CheckSpkControl "prefix='Left Front '"
+Macro.spkdet4.CheckSpkControl "prefix='Left Tweeter '"


### PR DESCRIPTION
Fixes speaker detection on M1 Mac mini / Fedora.